### PR TITLE
Document how to enable container domain names.

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -1,0 +1,25 @@
+Domain Names for Containers
+
+For convenience, it is possible to automatically map domain names to your
+containers' IP addresses.  This allows connecting to them from the host machine
+using names like mycontainer.lxc, rather than having to keep track of their
+numeric addresses.
+
+First, uncomment the following line in the host's /etc/default/lxc-net file:
+
+LXC_DOMAIN="lxc"
+
+Next, add the following line to the system dnsmasq configuration file:
+
+server=/lxc/10.0.3.1
+
+On Debian-based systems running NetworkManager, such as Ubuntu desktops, add
+that line to /etc/NetworkManager/dnsmasq.d/lxc.conf (or a similarly-named file
+in the same directory).  On systems without NetworkManager, add it to
+/etc/dnsmasq.conf instead.  You may have to create the file yourself.
+
+Finally, restart the lxc-net service, and the network-manager service if it is
+running on your system:  (These commands must be run as root.)
+
+invoke-rc.d lxc-net restart
+invoke-rc.d network-manager restart

--- a/debian/lxc.preinst
+++ b/debian/lxc.preinst
@@ -31,8 +31,10 @@ LXC_DHCP_MAX="253"
 
 # Uncomment the next line if you want lxcbr0's dnsmasq to resolve the .lxc
 # domain.  You can then add "server=/lxc/10.0.$i.1' (or your actual \$LXC_ADDR)
-# to /etc/dnsmasq.conf, after which 'container1.lxc' will resolve on your
-# host.
+# to your system dnsmasq configuration file (normally /etc/dnsmasq.conf,
+# or /etc/NetworkManager/dnsmasq.d/lxc.conf on systems that use NetworkManager).
+# Once these changes are made, restart the lxc-net and network-manager services.
+# 'container1.lxc' will then resolve on your host.
 #LXC_DOMAIN="lxc"
 EOF
 }

--- a/debian/lxc.preinst
+++ b/debian/lxc.preinst
@@ -30,7 +30,7 @@ LXC_DHCP_MAX="253"
 #LXC_DHCP_CONFILE=/etc/lxc/dnsmasq.conf
 
 # Uncomment the next line if you want lxcbr0's dnsmasq to resolve the .lxc
-# domain.  You can then add "server=/lxc/10.0.3.1' (or your actual $LXC_ADDR)
+# domain.  You can then add "server=/lxc/10.0.$i.1' (or your actual \$LXC_ADDR)
 # to /etc/dnsmasq.conf, after which 'container1.lxc' will resolve on your
 # host.
 #LXC_DOMAIN="lxc"


### PR DESCRIPTION
This is an attempt to help Debian and Ubuntu users discover how to enable domain names for containers, in response to the ubuntu bug report:
https://bugs.launchpad.net/ubuntu/+source/lxc/+bug/1389954
