### PR TITLE
Force lxc-instance to behave like a good Upstart client

### DIFF
--- a/config/init/upstart/lxc-instance.conf
+++ b/config/init/upstart/lxc-instance.conf
@@ -17,6 +17,4 @@ pre-start script
 	lxc-wait -s RUNNING -n $NAME -t 0 && { stop; exit 0; } || true
 end script
 
-script
-	exec lxc-start -n $NAME
-end script
+exec lxc-start -Fn $NAME


### PR DESCRIPTION
Upstart jobs are not supposed to daemonize unless abosolutely necessary. Which is normally not necessary at all and just complicates the maintenance.

Signed-off-by Andrey Repin anrdaemon@yandex.ru
