### PR TITLE
only move lxc bash completion from /etc if we installed it there

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: autotools-dev,
+               bash-completion,
                debhelper (>= 9),
                dh-apparmor,
                dh-autoreconf,

--- a/debian/rules
+++ b/debian/rules
@@ -68,8 +68,10 @@ override_dh_install:
 	mv debian/tmp/usr/share/doc/lxc debian/tmp/usr/share/doc/lxc-common
 
 	# move the bash completion profile
-	mkdir -p debian/tmp/usr/share/bash-completion
-	mv debian/tmp/etc/bash_completion.d debian/tmp/usr/share/bash-completion/completions
+	mkdir -p debian/tmp/usr/share/bash-completion/completions
+	if [ -f debian/tmp/etc/bash_completion.d/lxc ]; then \
+		mv debian/tmp/etc/bash_completion.d/lxc debian/tmp/usr/share/bash-completion/completions; \
+	fi
 	mv debian/tmp/usr/share/bash-completion/completions/lxc debian/tmp/usr/share/bash-completion/completions/lxc1
 	grep complete debian/tmp/usr/share/bash-completion/completions/lxc1 | sed "s/.* //g" | while read cmd; do \
 		ln -s lxc1 debian/tmp/usr/share/bash-completion/completions/$${cmd}; \


### PR DESCRIPTION
these days the installation should happen directly to /usr thanks to pkg-config