### PR TITLE
set systemdsystemunitdir

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,8 @@
 #!/usr/bin/make -f
 export DEB_BUILD_HARDENING = 1
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export systemdsystemunitdir = $(shell pkg-config --variable=systemdsystemunitdir systemd | sed s,^/,,)
+
 include /usr/share/dpkg/default.mk
 
 DEB_DH_INSTALLINIT_ARGS = --upstart-only


### PR DESCRIPTION
PPA builds on noble are failing due to lib/systemd not existing. /lib -> /usr/lib, but it does on jammy as well, where builds are passing.  I see in the questing packaging that systemdsystemunitdir is being set there, so am theorizing that setting that will fix the build for noble.